### PR TITLE
Update RescriptRelay.res

### DIFF
--- a/packages/rescript-relay/src/RescriptRelay.res
+++ b/packages/rescript-relay/src/RescriptRelay.res
@@ -643,15 +643,16 @@ module Context = {
 
   @module("react-relay")
   external context: React.Context.t<option<contextShape>> = "ReactRelayContext"
-  let provider = React.Context.provider(context)
 
   module Provider = {
     @react.component
-    let make = (~environment: Environment.t, ~children) =>
+    let make = (~environment: Environment.t, ~children) => {
+      let provider = React.Context.provider(context)
       React.createElement(
         provider,
         {"value": Some({"environment": environment}), "children": children},
       )
+    }
   }
 }
 


### PR DESCRIPTION
When running Jest on a file that uses `%relay` the `React.Context` is undefined when trying to call `React.Context.provider(context)`. Moving it to only run when using `<Provider />` solves the problem.

<img width="1101" alt="Screenshot 2022-05-19 at 15 54 19" src="https://user-images.githubusercontent.com/609536/169310414-7360134a-a62d-4299-b4bf-ca201dc548cf.png">

jest.config.js
```js
/*
 * For a detailed explanation regarding each configuration property, visit:
 * https://jestjs.io/docs/en/configuration.html
 */

module.exports = {
  // An array of file extensions your modules use
  collectCoverage: true,
  moduleFileExtensions: [
    "js",
    "mjs",
  ],

  // The glob patterns Jest uses to detect test files
  testMatch: [
    "**/__tests__/**/*_test.mjs",
  ],

  // A map from regular expressions to paths to transformers
  "transform": {
    "^.+\\.m?js$": "babel-jest"
  },

  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
  transformIgnorePatterns: [
    "/node_modules/(!(rescript|@glennsl/rescript-jest))"
  ],
};

```